### PR TITLE
Lua install: Language is spelt incorrectly

### DIFF
--- a/Linux/lua.sh
+++ b/Linux/lua.sh
@@ -1,13 +1,13 @@
 mkdir -p ~/local/share/nvim/lspinstall &&
 
-if [[ -d ~/.local/share/nvim/lspinstall/lua-langauge-server  ]]
+if [[ -d ~/.local/share/nvim/lspinstall/lua-language-server  ]]
 then
   echo "deleting old download of lua-language-server"
-  rm -rf ~/.local/share/nvim/lspinstall/lua-langauge-server
+  rm -rf ~/.local/share/nvim/lspinstall/lua-language-server
 fi &&
 
-git clone https://github.com/sumneko/lua-language-server ~/.local/share/nvim/lspinstall/lua-langauge-server &&
-cd ~/.local/share/nvim/lspinstall/lua-langauge-server &&
+git clone https://github.com/sumneko/lua-language-server ~/.local/share/nvim/lspinstall/lua-language-server &&
+cd ~/.local/share/nvim/lspinstall/lua-language-server &&
 git submodule update --init --recursive &&
 cd 3rd/luamake &&
 ninja -f ninja/linux.ninja &&


### PR DESCRIPTION
There is a small typo in the name of the lua language server directory. I just hit this trying to install it using the `nvim-lspinstall` plugin and didn't understand why the server wasn't working till I inspected the file and found that the install directory wasn't correctly named.